### PR TITLE
create database table for help requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a restaurant.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequest")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The HelpRequestRepository is a repository for HelpRequest entities
+ */
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequest-1",
+          "author": "jeffreylin26",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "helprequest"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HelpRequest_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTEREMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TEAMID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLEORBREAKOUTROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTTIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "helprequest"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #32 

This PR adds a new database table to store the help requests.

Includes the following fields:

long id
String requesterEmail
String teamId
String tableOrBreakoutRoom
LocalDateTime requestTime
String explanation
boolean solved

This can be verified by checking the H2 console in localhost. You can also use the dokku postgres:connect team01-db command on dokku, followed by \dt to show the table. 

This PR includes a new @entity class HelpRequest.java, @repository class HelpRequestRepository.java, and the database migration file HelpRequest.json.